### PR TITLE
Fixed footer overflow

### DIFF
--- a/index.css
+++ b/index.css
@@ -567,6 +567,7 @@
   align-items: center;
   justify-content: space-around;
   padding: 20px 25px;
+  position: absolute;
   bottom: 0;
   width: calc(100% - 50px);
   /* Adjusted width to account for padding */


### PR DESCRIPTION
This change resolves #9 by setting footer's position property to 'absolute' from the default value 'static' whic was causing the issue.